### PR TITLE
Accept laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "^5.0.*",
+        "laravel/framework": "^5.*",
         "laravel/tinker": "~1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "5.6.*",
+        "laravel/framework": "^5.0.*",
         "laravel/tinker": "~1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": ">=5 <6",
+        "laravel/framework": ">=5",
         "laravel/tinker": "~1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "^5.0",
+        "laravel/framework": ">=5 <6",
         "laravel/tinker": "~1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "^5.*",
+        "laravel/framework": "^5.0",
         "laravel/tinker": "~1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"


### PR DESCRIPTION
Right now your composer file just accept Laravel 5.6, the package can't be used on 5.4, 5.5, 5.8, 6.0 or any other version. And i have tested and it work on that versions, so it should be able to install it there.

So i just updated the composer.json to accept any laravel version after or equals to 5.0