### PR TITLE
Remove Tinker. Change version constraints.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "laravel/framework": "~5.1|^6.0",
+        "laravel/framework": "~5.1|^6.0|^7.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "laravel/framework": ">=5",
-        "laravel/tinker": "~1.0",
+        "php": "^7.1.3",
+        "laravel/framework": "~5.1|^6.0",
         "mailjet/mailjet-apiv3-php": "^1.2",
         "mailjet/mailjet-swiftmailer": "^2.0"
     },


### PR DESCRIPTION
I removed Tinker as it does not seem to be used at all.
Right now it is only causing problems with installation on Laravel 6.x (#26).
It also should fix previous issues from #18, #20.