### PR TITLE
Fix README providers array documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Please also set your email from address and name.
 'providers' => [
     ...
     Mailjet\LaravelMailjet\MailjetServiceProvider::class,
-    Mailjet\LaravelMailjet\MailjetMailServiceProvider::class,
     ...
 ]
 ```


### PR DESCRIPTION
The `Mailjet\LaravelMailjet\MailjetMailServiceProvider`  class has been removed in the last release (#52).

So it doesn't required anaymore.