### PR TITLE
Remove composer.phar from downloaded package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+composer.phar export-ignore


### PR DESCRIPTION
Hello,

IMHO composer.phar shouldn't be tracked in the git repository in the first place. However if it's more convenient for you I would suggest at least to remove it from the downloaded composer package.