### PR TITLE
Remove docs folder from distributed package to save 3.6 MB

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+/docs export-ignore


### PR DESCRIPTION
Trying to make my docker image leaner, I found the package is distributed with its doc containing heavy images.
![image](https://github.com/mailjet/laravel-mailjet/assets/1524501/3cceb6ca-8267-47f1-a89a-2965ca66c8ca)

I suggest to remove it from the distributed package.