### PR TITLE
Update dependencies to fix PHP 8.4 deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
-        "mailjet/mailjet-apiv3-php": "^1.5.6|^1.5",
+        "php": "^8.1",
+        "laravel/framework": "^10.0|^11.0|^12.0",
+        "mailjet/mailjet-apiv3-php": "^1.6.4",
         "symfony/http-client": "^7.1",
         "symfony/mailjet-mailer": "^6.0"
     },
@@ -41,7 +41,7 @@
         "mockery/mockery": "0.9.*|^1.0",
         "orchestra/testbench": "3.6|^4.0|^5.0|^6.0|^8.0|^9.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "~7.0|^8.0|^9|^10.0"
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
mailjet/mailjet-apiv3-php v.1.6.4 fixed deprecation warnings that arises in PHP 8.4

I updated the minimum version of this package to fix the deprecation warnings when using this package