### PR TITLE
issue_94, Add Laravel 12 and Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "php": "^7.4|^8.0",
         "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
         "mailjet/mailjet-apiv3-php": "^1.5.6|^1.5",
-        "symfony/http-client": "^7.1",
-        "symfony/mailjet-mailer": "^6.0"
+        "symfony/http-client": "^7.1|^8.0",
+        "symfony/mailjet-mailer": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "fakerphp/faker": "~1",

--- a/src/MailjetServiceProvider.php
+++ b/src/MailjetServiceProvider.php
@@ -21,12 +21,20 @@ class MailjetServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Mail::extend('mailjet', function () {
+            $options = [];
+
+            if (filter_var(config('services.mailjet.sandbox', false), FILTER_VALIDATE_BOOLEAN)) {
+                $options['sandbox'] = 'true';
+            }
+
             return (new MailjetTransportFactory)->create(
                 new Dsn(
                     'mailjet+api',
                     'default',
                     config('services.mailjet.key'),
-                    config('services.mailjet.secret')
+                    config('services.mailjet.secret'),
+                    null,
+                    $options
                 )
             );
         });


### PR DESCRIPTION
          Widen dependency constraints to resolve installation conflicts in
          Laravel 12 projects. Fix sandbox option not being passed to Mailjet
          transport DSN.

          Fixes #94