### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "mailjet/mailjet-apiv3-php": "^1.5.6|^1.5",
         "symfony/http-client": "^7.1|^8.0",
         "symfony/mailjet-mailer": "^6.0|^7.0|^8.0"


### PR DESCRIPTION
Checked the L13 upgrade guide. 
The only relevant breaking change is the Manager extend callback binding, but the Mail::extend() closure doesn't reference $this so we're unaffected. All other APIs this touches (ServiceProvider, Facade, container bindings, config helper, Symfony Dsn/MailjetTransportFactory) are unchanged in L13.